### PR TITLE
Fixed clipwarp position X

### DIFF
--- a/HobbitSpeedrunTools/src/windows/MainWindow.xaml.cs
+++ b/HobbitSpeedrunTools/src/windows/MainWindow.xaml.cs
@@ -433,8 +433,8 @@ namespace HobbitSpeedrunTools
 
         private void txtClipwarpPosX_PreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
-            Action<float> applyAction = cheatManager.SetClipwarpPositionZ;
-            float value = float.Parse(txtClipwarpPosZ.Text[3..]);
+            Action<float> applyAction = cheatManager.SetClipwarpPositionX;
+            float value = float.Parse(txtClipwarpPosX.Text[3..]);
             ShowEditPrompt("Clipwarp Position X:", value, applyAction);
         }
 


### PR DESCRIPTION
Fixed issue where clicking the clipwarp position for the X axis would display Z axis value.